### PR TITLE
Leverage PowerShellStandard.Library in Runtime

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,39 +1,39 @@
 <Project>
-
+  
   <PropertyGroup Label="Package Management">
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
+  
   <PropertyGroup Label="Build Settings">
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+
+  <ItemGroup Label="Microsoft NuGet Packages (Source)">
+    <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
+  </ItemGroup>
   
   <ItemGroup Label="Microsoft NuGet Packages (Source) (.NET 6)" Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.2.7" />
   </ItemGroup>
-
+  
   <ItemGroup Label="Microsoft NuGet Packages (Source) (.NET 7)" Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.3.0" />
   </ItemGroup>
-
+  
   <ItemGroup Label="Microsoft NuGet Packages (Test)">
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
-
+  
   <ItemGroup Label="External Testing Packages">
     <PackageVersion Include="Bogus" Version="34.0.2" />
     <PackageVersion Include="FluentAssertions" Version="6.8.0" />
     <PackageVersion Include="Moq" Version="4.18.2" />
   </ItemGroup>
-
-  <ItemGroup Label="Sample Projects">
-    <PackageVersion Include="AutomationIoC" Version="1.1.0" />
-  </ItemGroup>
-
+  
 </Project>

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Dependency Injection Framework for C# PowerShell Cmdlets
 
 ## Requirements
 
-- [.NET 6](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
-- [PowerShell 7](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.2)
+- [.NET 7](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) or [.NET 6](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
+- [PowerShell 7.3](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.3)
 
 ## Getting Started
 

--- a/sample/.vscode/launch.json
+++ b/sample/.vscode/launch.json
@@ -10,7 +10,7 @@
         "-NoExit",
         "-NoProfile",
         "-Command",
-        "Import-Module ${workspaceFolder}/src/bin/Debug/net6.0/AutomationIoC.Sample.dll",
+        "Import-Module ${workspaceFolder}/src/bin/Debug/net7.0/AutomationIoC.Sample.dll",
         "-Verbose"
       ],
       "cwd": "${workspaceFolder}",

--- a/sample/AutomationIoC.Sample.sln
+++ b/sample/AutomationIoC.Sample.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutomationIoC.Sample", "src\AutomationIoC.Sample.csproj", "{9DE9C1DC-2514-42C7-A746-45FC27DEAD21}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutomationIoC.Sample.Test", "test\AutomationIoC.Sample.Test.csproj", "{D49B9B29-9694-476E-94D6-1F0DE3B7A784}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutomationIoC.Sample.Test", "test\AutomationIoC.Sample.Test.csproj", "{D49B9B29-9694-476E-94D6-1F0DE3B7A784}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutomationIoC", "..\src\automation\AutomationIoC.csproj", "{07D5D71D-6278-4BC3-AF06-C5B430EEFF8E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{D49B9B29-9694-476E-94D6-1F0DE3B7A784}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D49B9B29-9694-476E-94D6-1F0DE3B7A784}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D49B9B29-9694-476E-94D6-1F0DE3B7A784}.Release|Any CPU.Build.0 = Release|Any CPU
+		{07D5D71D-6278-4BC3-AF06-C5B430EEFF8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{07D5D71D-6278-4BC3-AF06-C5B430EEFF8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07D5D71D-6278-4BC3-AF06-C5B430EEFF8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{07D5D71D-6278-4BC3-AF06-C5B430EEFF8E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sample/src/AutomationIoC.Sample.csproj
+++ b/sample/src/AutomationIoC.Sample.csproj
@@ -1,13 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>net7.0</TargetFramework>
+
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutomationIoC" />
+    <ProjectReference Include="..\..\src\automation\AutomationIoC.csproj" />
   </ItemGroup>
 
 </Project>

--- a/sample/src/Cmdlets/RequestCard.cs
+++ b/sample/src/Cmdlets/RequestCard.cs
@@ -2,26 +2,25 @@
 using Microsoft.Extensions.Logging;
 using System.Management.Automation;
 
-namespace AutomationIoC.Sample.Cmdlets
+namespace AutomationIoC.Sample.Cmdlets;
+
+[Cmdlet(VerbsLifecycle.Request, "Card")]
+public class RequestCard : IoCShell<Startup>
 {
-    [Cmdlet(VerbsLifecycle.Request, "Card")]
-    public class RequestCard : IoCShell<Startup>
+    [AutomationDependency]
+    protected IDeck CardDeck { get; set; }
+
+    [AutomationDependency]
+    private readonly ILogger<RequestCard> logger = default;
+
+    protected override void ProcessRecord()
     {
-        [AutomationDependency]
-        protected IDeck CardDeck { get; set; }
+        base.ProcessRecord();
 
-        [AutomationDependency]
-        private readonly ILogger<RequestCard> logger = default;
+        var card = CardDeck.Draw();
 
-        protected override void ProcessRecord()
-        {
-            base.ProcessRecord();
+        logger.LogInformation("Card Drawn: {Name}", card.ToString());
 
-            var card = CardDeck.Draw();
-
-            logger.LogInformation("Card Drawn: {Name}", card.ToString());
-
-            WriteObject(card);
-        }
+        WriteObject(card);
     }
 }

--- a/sample/src/Models/Card.cs
+++ b/sample/src/Models/Card.cs
@@ -1,37 +1,36 @@
-﻿namespace AutomationIoC.Sample.Models
+﻿namespace AutomationIoC.Sample.Models;
+
+public class Card
 {
-    public class Card
-    {
-        public Rank Rank { get; set; }
+    public Rank Rank { get; set; }
 
-        public Suit Suit { get; set; }
+    public Suit Suit { get; set; }
 
-        public override string ToString() =>
-            $"{Rank} of {Suit}s";
-    }
+    public override string ToString() =>
+        $"{Rank} of {Suit}s";
+}
 
-    public enum Rank
-    {
-        Ace = 1,
-        Two = 2,
-        Three = 3,
-        Four = 4,
-        Five = 5,
-        Six = 6,
-        Seven = 7,
-        Eight = 8,
-        Nine = 9,
-        Ten = 10,
-        Jack = 11,
-        Queen = 12,
-        King = 13
-    }
+public enum Rank
+{
+    Ace = 1,
+    Two = 2,
+    Three = 3,
+    Four = 4,
+    Five = 5,
+    Six = 6,
+    Seven = 7,
+    Eight = 8,
+    Nine = 9,
+    Ten = 10,
+    Jack = 11,
+    Queen = 12,
+    King = 13
+}
 
-    public enum Suit
-    {
-        Club,
-        Diamond,
-        Heart,
-        Spade
-    }
+public enum Suit
+{
+    Club,
+    Diamond,
+    Heart,
+    Spade
 }

--- a/sample/src/Models/Deck.cs
+++ b/sample/src/Models/Deck.cs
@@ -1,36 +1,37 @@
-﻿namespace AutomationIoC.Sample.Models
+﻿namespace AutomationIoC.Sample.Models;
+
+public class Deck : IDeck
 {
-    public class Deck : IDeck
+    private readonly Stack<Card> cards;
+
+    public Deck()
     {
-        private readonly Stack<Card> cards;
+        cards = new Stack<Card>();
+        Load();
+    }
 
-        public Deck()
+    public Card Draw()
+    {
+        return cards.Pop();
+    }
+
+    public void Load()
+    {
+        Rank[] ranks = Enum.GetValues(typeof(Rank)).Cast<Rank>().ToArray();
+        Suit[] suits = Enum.GetValues(typeof(Suit)).Cast<Suit>().ToArray();
+
+        foreach (Suit suit in suits)
         {
-            cards = new Stack<Card>();
-            Load();
-        }
-
-        public Card Draw()
-        {
-            return cards.Pop();
-        }
-
-        public void Load()
-        {
-            Rank[] ranks = Enum.GetValues(typeof(Rank)).Cast<Rank>().ToArray();
-            Suit[] suits = Enum.GetValues(typeof(Suit)).Cast<Suit>().ToArray();
-
-            foreach (Suit suit in suits)
-                foreach (Rank rank in ranks)
+            foreach (Rank rank in ranks)
+            {
+                var card = new Card()
                 {
-                    var card = new Card()
-                    {
-                        Rank = rank,
-                        Suit = suit
-                    };
+                    Rank = rank,
+                    Suit = suit
+                };
 
-                    cards.Push(card);
-                }
+                cards.Push(card);
+            }
         }
     }
 }

--- a/sample/src/Models/IDeck.cs
+++ b/sample/src/Models/IDeck.cs
@@ -1,9 +1,8 @@
-﻿namespace AutomationIoC.Sample.Models
-{
-    public interface IDeck
-    {
-        Card Draw();
+﻿namespace AutomationIoC.Sample.Models;
 
-        void Load();
-    }
+public interface IDeck
+{
+    Card Draw();
+
+    void Load();
 }

--- a/sample/src/Startup.cs
+++ b/sample/src/Startup.cs
@@ -2,23 +2,22 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace AutomationIoC.Sample
+namespace AutomationIoC.Sample;
+
+public class Startup : IoCStartup
 {
-    public class Startup : IoCStartup
+    public override void Configure(IConfigurationBuilder configurationBuilder)
     {
-        public override void Configure(IConfigurationBuilder configurationBuilder)
+        var appSettings = new Dictionary<string, string>()
         {
-            var appSettings = new Dictionary<string, string>()
-            {
-                ["player:mode"] = "Beginner",
-            };
+            ["player:mode"] = "Beginner",
+        };
 
-            configurationBuilder.AddInMemoryCollection(appSettings);
-        }
+        configurationBuilder.AddInMemoryCollection(appSettings);
+    }
 
-        public override void ConfigureServices(IServiceCollection services)
-        {
-            services.AddSingleton<IDeck, Deck>();
-        }
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddSingleton<IDeck, Deck>();
     }
 }

--- a/sample/test/AutomationIoC.Sample.Test.csproj
+++ b/sample/test/AutomationIoC.Sample.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/sample/test/Cmdlets/RequestCardTests.cs
+++ b/sample/test/Cmdlets/RequestCardTests.cs
@@ -6,25 +6,24 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 
-namespace AutomationIoC.Sample.Test.Cmdlets
+namespace AutomationIoC.Sample.Test.Cmdlets;
+
+public class RequestCardTests
 {
-    public class RequestCardTests
+    [Fact]
+    public void ShouldRequestCard()
     {
-        [Fact]
-        public void ShouldRequestCard()
-        {
-            var deckMock = new Mock<IDeck>();
-            var expectedCard = new Card { Rank = Rank.Ace, Suit = Suit.Spade };
+        var deckMock = new Mock<IDeck>();
+        var expectedCard = new Card { Rank = Rank.Ace, Suit = Suit.Spade };
 
-            using var requestCardCommand =
-                AutomationSandbox.CreateContext<RequestCard, Startup>(services =>
-                    services.AddTransient(_ => deckMock.Object));
+        using var requestCardCommand =
+            AutomationSandbox.CreateContext<RequestCard, Startup>(services =>
+                services.AddTransient(_ => deckMock.Object));
 
-            deckMock.Setup(deck => deck.Draw()).Returns(expectedCard);
+        deckMock.Setup(deck => deck.Draw()).Returns(expectedCard);
 
-            var actualCard = requestCardCommand.RunCommand<Card>().First();
+        var actualCard = requestCardCommand.RunCommand<Card>().First();
 
-            actualCard.Should().BeEquivalentTo(expectedCard);
-        }
+        actualCard.Should().BeEquivalentTo(expectedCard);
     }
 }

--- a/src/runtime/AutomationIoC.Runtime.csproj
+++ b/src/runtime/AutomationIoC.Runtime.csproj
@@ -12,6 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" />
+    <PackageReference Include="PowerShellStandard.Library" />
   </ItemGroup>
 </Project>

--- a/src/tools/AutomationIoC.Tools.csproj
+++ b/src/tools/AutomationIoC.Tools.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
@@ -10,6 +10,10 @@
     <Description>Development tools for running/testing Cmdlets built with AutomationIoC framework</Description>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.PowerShell.SDK" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\runtime\AutomationIoC.Runtime.csproj" />
   </ItemGroup>


### PR DESCRIPTION
- Changed to PowerShellStandard.Library as Runtime and SDK reference. PowerShellStandard.Library is more portable between various PowerShell runtimes which will allow Runtime and SDK to work on multiple versions of PowerShell. This also makes the package lighter.

- Microsoft.PowerShell.SDK is still leveraged in Tools package since it needs the ability to stand-up its own PowerShell instance/resources.