### PR TITLE
Remove PowerShell Dependency From Runtime

### DIFF
--- a/src/pscmdlets/core/integration/Commands/TestContextCommand.cs
+++ b/src/pscmdlets/core/integration/Commands/TestContextCommand.cs
@@ -6,6 +6,7 @@
 using AutomationIoC.PSCmdlets.Integration.Attributes;
 using AutomationIoC.PSCmdlets.Integration.Services;
 using AutomationIoC.PSCmdlets.Integration.Startup;
+using AutomationIoC.PSCmdlets.Session;
 using AutomationIoC.Runtime;
 using System.Management.Automation;
 
@@ -24,7 +25,7 @@ public class TestContextCommand : PSCmdlet
         var dependencyContext = new DependencyContext<TestToolsAttribute, TestStartup>
         {
             Instance = this,
-            SessionState = SessionState
+            SessionState = new SessionStateProxy(SessionState)
         };
 
         AutomationIoCRuntime.BindContext(dependencyContext);

--- a/src/pscmdlets/core/src/AutomationIoC.PSCmdlets.csproj
+++ b/src/pscmdlets/core/src/AutomationIoC.PSCmdlets.csproj
@@ -11,6 +11,10 @@
     <Description>PSCmdlet SDK utilities for AutomationIoC framework development</Description>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="PowerShellStandard.Library" />
+  </ItemGroup>
+  
   <ItemGroup Label="NuGet Artifacts">
     <None Include="..\..\..\..\AutomationIoC.png" Pack="true" PackagePath="\" Visible="false"  />
     <None Include="..\..\..\..\README.md" Pack="true" PackagePath="\" Visible="false"/>

--- a/src/pscmdlets/core/src/IoCShell.cs
+++ b/src/pscmdlets/core/src/IoCShell.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License
 // -------------------------------------------------------
 
+using AutomationIoC.PSCmdlets.Session;
 using AutomationIoC.Runtime;
 using System.Management.Automation;
 
@@ -21,7 +22,7 @@ public abstract class IoCShell<TStartup> : PSCmdlet where TStartup : IIoCStartup
         var dependencyContext = new DependencyContext<AutomationDependencyAttribute, TStartup>
         {
             Instance = this,
-            SessionState = SessionState
+            SessionState = new SessionStateProxy(SessionState)
         };
 
         AutomationIoCRuntime.BindContext(dependencyContext);

--- a/src/pscmdlets/core/src/IoCVariable.cs
+++ b/src/pscmdlets/core/src/IoCVariable.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License
 // -------------------------------------------------------
 
+using AutomationIoC.PSCmdlets.Session;
 using AutomationIoC.Runtime;
 using System.Management.Automation;
 
@@ -10,5 +11,6 @@ namespace AutomationIoC.PSCmdlets;
 
 public abstract class IoCVariable : PSCmdlet
 {
-    protected void SetVariable(string key, object value) => AutomationIoCRuntime.SetEnvironment(SessionState, key, value);
+    protected void SetVariable(string key, object value) =>
+        AutomationIoCRuntime.SetEnvironment(new SessionStateProxy(SessionState), key, value);
 }

--- a/src/pscmdlets/core/src/Properties/AssemblyInfo.cs
+++ b/src/pscmdlets/core/src/Properties/AssemblyInfo.cs
@@ -5,5 +5,6 @@
 
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("AutomationIoC.PSCmdlets.Integration.Test")]
 [assembly: InternalsVisibleTo("AutomationIoC.PSCmdlets.Test")]
 [assembly: InternalsVisibleTo("AutomationIoC.PSCmdlets.Tools")]

--- a/src/pscmdlets/core/src/Session/IPowerShellSessionState.cs
+++ b/src/pscmdlets/core/src/Session/IPowerShellSessionState.cs
@@ -5,9 +5,9 @@
 
 using System.Management.Automation;
 
-namespace AutomationIoC.Runtime.Session;
+namespace AutomationIoC.PSCmdlets.Session;
 
-internal interface ISessionState
+internal interface IPowerShellSessionState
 {
     List<string> Applications { get; }
 

--- a/src/pscmdlets/core/src/Session/SessionStateProxy.cs
+++ b/src/pscmdlets/core/src/Session/SessionStateProxy.cs
@@ -3,12 +3,13 @@
 // Licensed under the MIT License
 // -------------------------------------------------------
 
+using AutomationIoC.Runtime;
 using System.Management.Automation;
 using Runspace = System.Management.Automation.Runspaces;
 
-namespace AutomationIoC.Runtime.Session;
+namespace AutomationIoC.PSCmdlets.Session;
 
-internal class SessionStateProxy : ISessionState
+internal class SessionStateProxy : IPowerShellSessionState, ISessionState
 {
     private readonly SessionState sessionState;
     private readonly Runspace.SessionStateProxy sessionStateProxy;
@@ -44,4 +45,19 @@ internal class SessionStateProxy : ISessionState
     public List<string> Scripts => sessionState?.Scripts ?? sessionStateProxy.Scripts;
 
     public bool UseFullLanguageModeInDebugger => sessionState?.UseFullLanguageModeInDebugger ?? false;
+
+    public T GetValue<T>(string key)
+    {
+        PSVariable psVariable = sessionState.PSVariable.Get(key);
+
+        return psVariable?.Value is not null ? (T)psVariable.Value : default;
+    }
+
+    public void SetValue<T>(string key, T value)
+    {
+        PSVariable serviceVariable =
+                new(key, value, ScopedItemOptions.None);
+
+        sessionState.PSVariable.Set(serviceVariable);
+    }
 }

--- a/src/pscmdlets/core/src/Session/SessionStateProxy.cs
+++ b/src/pscmdlets/core/src/Session/SessionStateProxy.cs
@@ -48,7 +48,7 @@ internal class SessionStateProxy : IPowerShellSessionState, ISessionState
 
     public T GetValue<T>(string key)
     {
-        PSVariable psVariable = sessionState.PSVariable.Get(key);
+        PSVariable psVariable = PSVariable.Get(key);
 
         return psVariable?.Value is not null ? (T)psVariable.Value : default;
     }
@@ -58,6 +58,6 @@ internal class SessionStateProxy : IPowerShellSessionState, ISessionState
         PSVariable serviceVariable =
                 new(key, value, ScopedItemOptions.None);
 
-        sessionState.PSVariable.Set(serviceVariable);
+        PSVariable.Set(serviceVariable);
     }
 }

--- a/src/pscmdlets/tools/src/AutomationIoC.PSCmdlets.Tools.csproj
+++ b/src/pscmdlets/tools/src/AutomationIoC.PSCmdlets.Tools.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\runtime\src\AutomationIoC.Runtime.csproj" />
+    <ProjectReference Include="..\..\core\src\AutomationIoC.PSCmdlets.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/pscmdlets/tools/src/Command/AutomationContextCommand.cs
+++ b/src/pscmdlets/tools/src/Command/AutomationContextCommand.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License
 // -------------------------------------------------------
 
+using AutomationIoC.PSCmdlets.Session;
 using AutomationIoC.Runtime;
 using Microsoft.Extensions.DependencyInjection;
 using System.Management.Automation;
@@ -19,6 +20,7 @@ internal class AutomationContextCommand<TCommand, TStartup> : AutomationCommand<
 
         buildServices(services);
 
-        AutomationIoCRuntime.BuildServices<TStartup>(powerShellSession.Runspace.SessionStateProxy, services);
+        AutomationIoCRuntime.BuildServices<TStartup>(
+            new SessionStateProxy(powerShellSession.Runspace.SessionStateProxy), services);
     }
 }

--- a/src/runtime/src/AutomationIoC.Runtime.csproj
+++ b/src/runtime/src/AutomationIoC.Runtime.csproj
@@ -17,6 +17,5 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
-    <PackageReference Include="PowerShellStandard.Library" />
   </ItemGroup>
 </Project>

--- a/src/runtime/src/AutomationIoCRuntime.cs
+++ b/src/runtime/src/AutomationIoCRuntime.cs
@@ -7,10 +7,7 @@ using AutomationIoC.Runtime.Binder;
 using AutomationIoC.Runtime.Context;
 using AutomationIoC.Runtime.Dependency;
 using AutomationIoC.Runtime.Environment;
-using AutomationIoC.Runtime.Session;
 using Microsoft.Extensions.DependencyInjection;
-using System.Management.Automation;
-using Runspace = System.Management.Automation.Runspaces;
 
 namespace AutomationIoC.Runtime;
 
@@ -20,9 +17,7 @@ public static class AutomationIoCRuntime
         where TAttribute : Attribute
         where TStartup : IIoCStartup, new()
     {
-        var sessionStateProxy = new SessionStateProxy(context.SessionState);
-
-        IServiceProvider serviceProvider = RuntimeFactory.RuntimeServiceProvider(sessionStateProxy, new TStartup());
+        IServiceProvider serviceProvider = RuntimeFactory.RuntimeServiceProvider(context.SessionState, new TStartup());
         using IServiceScope scope = serviceProvider.CreateScope();
 
         IAutomationIoCBinder binder = scope.ServiceProvider.GetRequiredService<IAutomationIoCBinder>();
@@ -30,12 +25,10 @@ public static class AutomationIoCRuntime
         binder.BindContext<TAttribute>(context.Instance);
     }
 
-    public static void BuildServices<TStartup>(Runspace.SessionStateProxy sessionStateProxy, IServiceCollection serviceCollection)
+    public static void BuildServices<TStartup>(ISessionState sessionState, IServiceCollection serviceCollection)
         where TStartup : IIoCStartup, new()
     {
-        var automationSessionStateProxy = new SessionStateProxy(sessionStateProxy);
-
-        IServiceProvider serviceProvider = RuntimeFactory.RuntimeServiceProvider(automationSessionStateProxy, new TStartup());
+        IServiceProvider serviceProvider = RuntimeFactory.RuntimeServiceProvider(sessionState, new TStartup());
         using IServiceScope scope = serviceProvider.CreateScope();
 
         IContextBuilder contextBuilder = scope.ServiceProvider.GetRequiredService<IContextBuilder>();
@@ -43,15 +36,13 @@ public static class AutomationIoCRuntime
         contextBuilder.BuildServices(serviceCollection);
     }
 
-    public static void SetEnvironment(SessionState sessionState, string key, object value)
+    public static void SetEnvironment(ISessionState sessionState, string key, object value)
     {
-        var sessionStateProxy = new SessionStateProxy(sessionState);
-
-        IServiceProvider runtimeServiceProvider = RuntimeFactory.RuntimeServiceProvider(sessionStateProxy);
+        IServiceProvider runtimeServiceProvider = RuntimeFactory.RuntimeServiceProvider(sessionState);
         using IServiceScope scope = runtimeServiceProvider.CreateScope();
 
         IEnvironmentStorageProvider environmentStorageProvider = scope.ServiceProvider.GetService<IEnvironmentStorageProvider>();
 
-        environmentStorageProvider.SetEnvironmentVariable(key, value, ScopedItemOptions.None);
+        environmentStorageProvider.SetEnvironmentVariable(key, value);
     }
 }

--- a/src/runtime/src/Dependency/RuntimeFactory.cs
+++ b/src/runtime/src/Dependency/RuntimeFactory.cs
@@ -14,7 +14,7 @@ namespace AutomationIoC.Runtime.Dependency;
 
 internal static class RuntimeFactory
 {
-    public static IServiceProvider RuntimeServiceProvider(SessionStateProxy sessionState, IIoCStartup startup) =>
+    public static IServiceProvider RuntimeServiceProvider(ISessionState sessionState, IIoCStartup startup) =>
         GenerateRuntimeDependencies(sessionState)
             .AddTransient<IAutomationIoCBinder, AutomationIoCBinder>()
             .AddTransient<IContextBuilder, ContextBuilder>()
@@ -22,7 +22,7 @@ internal static class RuntimeFactory
             .AddTransient(_ => startup)
             .BuildServiceProvider();
 
-    public static IServiceProvider RuntimeServiceProvider(SessionStateProxy sessionState) =>
+    public static IServiceProvider RuntimeServiceProvider(ISessionState sessionState) =>
         GenerateRuntimeDependencies(sessionState)
             .BuildServiceProvider();
 
@@ -31,7 +31,7 @@ internal static class RuntimeFactory
             .AddTransient<IDependencyBinder, DependencyBinder>()
             .AddLogging(builder => builder.AddConsole());
 
-    private static IServiceCollection GenerateRuntimeDependencies(SessionStateProxy sessionState) =>
+    private static IServiceCollection GenerateRuntimeDependencies(ISessionState sessionState) =>
         new ServiceCollection()
             .AddTransient<IAutomationEnvironment, AutomationEnvironment>()
             .AddTransient<IEnvironmentStorageProvider, EnvironmentStorageProvider>()

--- a/src/runtime/src/Environment/EnvironmentStorageProvider.cs
+++ b/src/runtime/src/Environment/EnvironmentStorageProvider.cs
@@ -3,9 +3,6 @@
 // Licensed under the MIT License
 // -------------------------------------------------------
 
-using AutomationIoC.Runtime.Session;
-using System.Management.Automation;
-
 namespace AutomationIoC.Runtime.Environment;
 
 internal class EnvironmentStorageProvider : IEnvironmentStorageProvider
@@ -17,18 +14,7 @@ internal class EnvironmentStorageProvider : IEnvironmentStorageProvider
         this.sessionState = sessionState;
     }
 
-    public T GetEnvironmentVariable<T>(string key)
-    {
-        PSVariable psVariable = sessionState.PSVariable.Get(key);
+    public T GetEnvironmentVariable<T>(string key) => sessionState.GetValue<T>(key);
 
-        return psVariable?.Value is not null ? (T)psVariable.Value : default;
-    }
-
-    public void SetEnvironmentVariable(string key, object value, ScopedItemOptions scopedItemOptions)
-    {
-        PSVariable serviceVariable =
-                new(key, value, scopedItemOptions);
-
-        sessionState.PSVariable.Set(serviceVariable);
-    }
+    public void SetEnvironmentVariable<T>(string key, T value) => sessionState.SetValue<T>(key, value);
 }

--- a/src/runtime/src/Environment/IEnvironmentStorageProvider.cs
+++ b/src/runtime/src/Environment/IEnvironmentStorageProvider.cs
@@ -3,13 +3,11 @@
 // Licensed under the MIT License
 // -------------------------------------------------------
 
-using System.Management.Automation;
-
 namespace AutomationIoC.Runtime.Environment;
 
 internal interface IEnvironmentStorageProvider
 {
-    void SetEnvironmentVariable(string key, object value, ScopedItemOptions scopedItemOptions);
+    void SetEnvironmentVariable<T>(string key, T value);
 
     T GetEnvironmentVariable<T>(string key);
 }

--- a/src/runtime/src/ISessionState.cs
+++ b/src/runtime/src/ISessionState.cs
@@ -5,11 +5,9 @@
 
 namespace AutomationIoC.Runtime;
 
-public class DependencyContext<TAttribute, TStartup>
-    where TAttribute : Attribute
-    where TStartup : IIoCStartup, new()
+public interface ISessionState
 {
-    public ISessionState SessionState { get; set; }
+    T GetValue<T>(string key);
 
-    public object Instance { get; set; }
+    void SetValue<T>(string key, T item);
 }

--- a/src/runtime/src/Session/SessionStorageProvider.cs
+++ b/src/runtime/src/Session/SessionStorageProvider.cs
@@ -5,7 +5,6 @@
 
 using AutomationIoC.Runtime.Environment;
 using Microsoft.Extensions.Hosting;
-using System.Management.Automation;
 
 namespace AutomationIoC.Runtime.Session;
 
@@ -26,5 +25,5 @@ internal class SessionStorageProvider : ISessionStorageProvider
         environmentStorageProvider.GetEnvironmentVariable<IHost>(StorageKey)?.Services;
 
     public void StoreHostProvider(IHost hostProvider) =>
-        environmentStorageProvider.SetEnvironmentVariable(StorageKey, hostProvider, ScopedItemOptions.ReadOnly);
+        environmentStorageProvider.SetEnvironmentVariable(StorageKey, hostProvider);
 }

--- a/src/runtime/test/Binder/AutomationIoCBinderTests.cs
+++ b/src/runtime/test/Binder/AutomationIoCBinderTests.cs
@@ -4,8 +4,8 @@
 // -------------------------------------------------------
 
 using AutomationIoC.Runtime.Attributes;
-using AutomationIoC.Runtime.Models;
 using AutomationIoC.Runtime.Context;
+using AutomationIoC.Runtime.Models;
 using Moq;
 using Xunit;
 
@@ -25,7 +25,7 @@ public class AutomationIoCBinderTests
     }
 
     [Fact]
-    public void ShouldInitializeyContext()
+    public void ShouldInitializeContext()
     {
         var instance = new TestInstance(123);
 

--- a/src/runtime/test/Dependency/RuntimeFactoryTests.cs
+++ b/src/runtime/test/Dependency/RuntimeFactoryTests.cs
@@ -3,17 +3,16 @@
 // Licensed under the MIT License
 // -------------------------------------------------------
 
-using AutomationIoC.Runtime.Startup;
 using AutomationIoC.Runtime.Binder;
 using AutomationIoC.Runtime.Context;
 using AutomationIoC.Runtime.Environment;
+using AutomationIoC.Runtime.Models;
 using AutomationIoC.Runtime.Session;
+using AutomationIoC.Runtime.Startup;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System.Management.Automation;
 using Xunit;
-using Runspace = System.Management.Automation.Runspaces;
 
 namespace AutomationIoC.Runtime.Dependency;
 
@@ -22,7 +21,7 @@ public class RuntimeFactoryTests
     [Fact]
     public void ShouldBuildRuntimeProviderFromSession()
     {
-        var sessionState = new SessionStateProxy(null as SessionState);
+        var sessionState = new TestSessionState();
         var startup = new TestRuntimeStartup();
 
         IServiceProvider actualServiceProvider = RuntimeFactory.RuntimeServiceProvider(sessionState, startup);
@@ -44,7 +43,7 @@ public class RuntimeFactoryTests
     [Fact]
     public void ShouldBuildRuntimeProviderFromSessionStatProxy()
     {
-        var sessionState = new SessionStateProxy(null as Runspace.SessionStateProxy);
+        var sessionState = new TestSessionState();
 
         IServiceProvider actualServiceProvider = RuntimeFactory.RuntimeServiceProvider(sessionState);
 

--- a/src/runtime/test/Environment/AutomationEnvironmentTests.cs
+++ b/src/runtime/test/Environment/AutomationEnvironmentTests.cs
@@ -52,7 +52,7 @@ public class AutomationEnvironmentTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void ShouldSendVaraibleIfExistReturnFalseIfNot(bool variableExists)
+    public void ShouldSendVariableIfExistReturnFalseIfNot(bool variableExists)
     {
         var id = Guid.NewGuid();
         var key = id.ToString();

--- a/src/runtime/test/Environment/EnvironmentStorageProviderTests.cs
+++ b/src/runtime/test/Environment/EnvironmentStorageProviderTests.cs
@@ -3,83 +3,62 @@
 // Licensed under the MIT License
 // -------------------------------------------------------
 
-using AutomationIoC.Runtime.Session;
 using Moq;
-using System.Management.Automation;
-using System.Management.Automation.Runspaces;
 using Xunit;
 
 namespace AutomationIoC.Runtime.Environment;
 
 public class EnvironmentStorageProviderTests
 {
-    [Fact(Skip = "Moving PS Out of Runtime project for 2.0")]
+    private readonly Mock<ISessionState> sessionStateMock;
+
+    private readonly IEnvironmentStorageProvider environmentStorageProvider;
+
+    public EnvironmentStorageProviderTests()
+    {
+        sessionStateMock = new();
+
+        environmentStorageProvider = new EnvironmentStorageProvider(sessionStateMock.Object);
+    }
+
+    [Fact]
     public void ShouldGetEnvironmentVariable()
     {
         var key = Guid.NewGuid().ToString();
         var expectedValue = Guid.NewGuid();
-        ScopedItemOptions scope = ScopedItemOptions.Unspecified;
 
-        var sessionStateMock = new Mock<ISessionState>();
-        PSVariable serviceVariable = new(key, expectedValue, scope);
+        sessionStateMock.Setup(state => state.GetValue<Guid>(key)).Returns(expectedValue);
 
-        Runspace runspace = RunspaceFactory.CreateRunspace(InitialSessionState.CreateDefault());
-        runspace.Open();
-
-        PSVariableIntrinsics psVariableIntrinsics = runspace.SessionStateProxy.PSVariable;
-
-        psVariableIntrinsics.Set(serviceVariable);
-
-        sessionStateMock.SetupGet(state => state.PSVariable).Returns(psVariableIntrinsics);
-
-        var storageProvider = new EnvironmentStorageProvider(sessionStateMock.Object);
-
-        Guid actualValue = storageProvider.GetEnvironmentVariable<Guid>(key);
+        Guid actualValue = environmentStorageProvider.GetEnvironmentVariable<Guid>(key);
 
         Assert.Equal(expectedValue, actualValue);
     }
 
-    [Fact(Skip = "Moving PS Out of Runtime project for 2.0")]
+    [Fact]
     public void ShouldReturnNullIfVariableDoesNotExist()
     {
         var key = Guid.NewGuid().ToString();
-        var value = Guid.NewGuid().ToString();
+        string expectedValue = null;
 
-        var sessionStateMock = new Mock<ISessionState>();
+        sessionStateMock.Setup(state => state.GetValue<string>(key)).Returns(expectedValue);
 
-        Runspace runspace = RunspaceFactory.CreateRunspace(InitialSessionState.CreateDefault());
-        runspace.Open();
-
-        PSVariableIntrinsics psVariableIntrinsics = runspace.SessionStateProxy.PSVariable;
-
-        sessionStateMock.SetupGet(state => state.PSVariable).Returns(psVariableIntrinsics);
-
-        var storageProvider = new EnvironmentStorageProvider(sessionStateMock.Object);
-
-        Guid? actualValue = storageProvider.GetEnvironmentVariable<Guid?>(key);
+        var actualValue = environmentStorageProvider.GetEnvironmentVariable<string>(key);
 
         Assert.Null(actualValue);
     }
 
-    [Fact(Skip = "Moving PS Out of Runtime project for 2.0")]
+    [Fact]
     public void ShouldStoreEnvironmentVariable()
     {
         var key = Guid.NewGuid().ToString();
         var value = Guid.NewGuid();
-        ScopedItemOptions scope = ScopedItemOptions.Constant;
 
-        var sessionStateMock = new Mock<ISessionState>();
+        sessionStateMock.Setup(state => state.SetValue(key, value));
 
-        PSVariable serviceVariable =
-                new(key, value, scope);
+        var storageProvider = new EnvironmentStorageProvider(sessionStateMock.Object);
 
-        Runspace runspace = RunspaceFactory.CreateRunspace(InitialSessionState.CreateDefault());
-        runspace.Open();
+        storageProvider.SetEnvironmentVariable(key, value);
 
-        PSVariableIntrinsics psVariableIntrinsics = runspace.SessionStateProxy.PSVariable;
-
-        psVariableIntrinsics.Set(serviceVariable);
-
-        sessionStateMock.SetupGet(state => state.PSVariable).Returns(psVariableIntrinsics);
+        sessionStateMock.Verify(state => state.SetValue(key, value), Times.Once);
     }
 }

--- a/src/runtime/test/Models/TestSessionState.cs
+++ b/src/runtime/test/Models/TestSessionState.cs
@@ -1,0 +1,12 @@
+﻿// -------------------------------------------------------
+// Copyright (c) Ken Swan All rights reserved.
+// Licensed under the MIT License
+// -------------------------------------------------------
+
+namespace AutomationIoC.Runtime.Models;
+internal class TestSessionState : ISessionState
+{
+    public T GetValue<T>(string key) => throw new NotImplementedException();
+
+    public void SetValue<T>(string key, T item) => throw new NotImplementedException();
+}

--- a/src/runtime/test/Startup/TestRuntimeStartup.cs
+++ b/src/runtime/test/Startup/TestRuntimeStartup.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------
 
 using AutomationIoC.Runtime.Services;
-using AutomationIoC.Runtime;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 


### PR DESCRIPTION
To allow for more IoC types in the upcoming releases (CommandLine), removing PowerShell dependency from Runtime via interface `ISessionState` which can bind PowerShell session in higher-level with `SessionStateProxy`