### PR TITLE
Provide HostBuilderContext in Startup Services

### DIFF
--- a/src/pscmdlets/core/integration/Commands/TestPSCmdletCommand.cs
+++ b/src/pscmdlets/core/integration/Commands/TestPSCmdletCommand.cs
@@ -10,7 +10,7 @@ using System.Management.Automation;
 namespace AutomationIoC.PSCmdlets.Integration.Commands;
 
 [Cmdlet(VerbsCommon.Get, "TestSDKCommand")]
-public class TestSDKCommand : IoCShell<TestStartup>
+public class TestPSCmdletCommand : IoCShell<TestStartup>
 {
     [AutomationDependency]
     protected readonly ITestService testService;

--- a/src/pscmdlets/core/integration/IoCShellTests.cs
+++ b/src/pscmdlets/core/integration/IoCShellTests.cs
@@ -16,7 +16,7 @@ public class IoCShellTests
     {
         var expectedValue = 3;
 
-        using IAutomationCommand<TestSDKCommand> context = AutomationSandbox.CreateCommand<TestSDKCommand>();
+        using IAutomationCommand<TestPSCmdletCommand> context = AutomationSandbox.CreateCommand<TestPSCmdletCommand>();
 
         var actualValue = context.RunCommand<int>().FirstOrDefault();
 

--- a/src/pscmdlets/core/integration/Models/TestRuntimeStartup.cs
+++ b/src/pscmdlets/core/integration/Models/TestRuntimeStartup.cs
@@ -7,6 +7,7 @@ using AutomationIoC.PSCmdlets.Integration.Services;
 using AutomationIoC.Runtime;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace AutomationIoC.PSCmdlets.Integration.Models;
 
@@ -29,7 +30,7 @@ public class TestRuntimeStartup : IIoCStartup
         configurationBuilder.AddInMemoryCollection(appSettings);
     }
 
-    public void ConfigureServices(IServiceCollection services) => services
+    public void ConfigureServices(HostBuilderContext hostBuilderContext, IServiceCollection services) => services
             .AddTransient<ITestRuntimeService, TestRuntimePropertyService>()
             .AddTransient<ITestRuntimeService, TestRuntimeFieldService>()
             .AddTransient<ITestRuntimeInternalServiceOne, TestRuntimeInternalServiceOne>()

--- a/src/pscmdlets/core/integration/Services/TestPSCmdletService.cs
+++ b/src/pscmdlets/core/integration/Services/TestPSCmdletService.cs
@@ -5,13 +5,13 @@
 
 namespace AutomationIoC.PSCmdlets.Integration.Services;
 
-public class TestSdkFieldService : TestSdkService
+public class TestPSCmdletFieldService : TestPSCmdletService
 {
     [AutomationDependency]
-    protected ITestSdkInternalServiceOne testRuntimeInternalServiceOne = default;
+    protected ITestPSCmdletInternalServiceOne testRuntimeInternalServiceOne = default;
 
     [AutomationDependency]
-    protected ITestSdkInternalServiceTwo testRuntimeInternalServiceTwo = default;
+    protected ITestPSCmdletInternalServiceTwo testRuntimeInternalServiceTwo = default;
 
     public override void RunMethod()
     {
@@ -22,13 +22,13 @@ public class TestSdkFieldService : TestSdkService
     }
 }
 
-public class TestSdkPropertyService : TestSdkService
+public class TestPSCmdletPropertyService : TestPSCmdletService
 {
     [AutomationDependency]
-    protected ITestSdkInternalServiceOne TestSdkInternalServiceOne { get; set; }
+    protected ITestPSCmdletInternalServiceOne TestSdkInternalServiceOne { get; set; }
 
     [AutomationDependency]
-    protected ITestSdkInternalServiceTwo TestSdkInternalServiceTwo { get; set; }
+    protected ITestPSCmdletInternalServiceTwo TestSdkInternalServiceTwo { get; set; }
 
     public override void RunMethod()
     {
@@ -39,7 +39,7 @@ public class TestSdkPropertyService : TestSdkService
     }
 }
 
-public class TestSdkService : ITestSdkService
+public class TestPSCmdletService : ITestPSCmdletService
 {
     public int CallCount { get; protected set; }
 
@@ -52,7 +52,7 @@ public class TestSdkService : ITestSdkService
     }
 }
 
-public interface ITestSdkService
+public interface ITestPSCmdletService
 {
     int CallCount { get; }
     bool WasCalled { get; }
@@ -60,6 +60,6 @@ public interface ITestSdkService
     void RunMethod();
 }
 
-public interface ITestSdkInternalServiceOne : ITestSdkService { }
+public interface ITestPSCmdletInternalServiceOne : ITestPSCmdletService { }
 
-public interface ITestSdkInternalServiceTwo : ITestSdkService { }
+public interface ITestPSCmdletInternalServiceTwo : ITestPSCmdletService { }

--- a/src/pscmdlets/core/integration/Startup/TestPSCmdletStartup.cs
+++ b/src/pscmdlets/core/integration/Startup/TestPSCmdletStartup.cs
@@ -6,16 +6,15 @@
 using AutomationIoC.Runtime;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace AutomationIoC.PSCmdlets.Integration.Startup;
 
-public class TestSDKStartup : IIoCStartup
+public class TestPSCmdletStartup : IIoCStartup
 {
-    public IConfiguration Configuration { get; set; }
-
     public IAutomationEnvironment AutomationEnvironment { get; set; }
 
     public void Configure(IConfigurationBuilder configurationBuilder) => throw new NotImplementedException();
 
-    public void ConfigureServices(IServiceCollection services) => throw new NotImplementedException();
+    public void ConfigureServices(HostBuilderContext hostBuilderContext, IServiceCollection services) => throw new NotImplementedException();
 }

--- a/src/pscmdlets/core/integration/Startup/TestStartup.cs
+++ b/src/pscmdlets/core/integration/Startup/TestStartup.cs
@@ -6,6 +6,7 @@
 using AutomationIoC.PSCmdlets.Integration.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace AutomationIoC.PSCmdlets.Integration.Startup;
 
@@ -21,5 +22,6 @@ public class TestStartup : IoCStartup
         configurationBuilder.AddInMemoryCollection(appSettings);
     }
 
-    public override void ConfigureServices(IServiceCollection services) => services.AddTransient<ITestService, TestService>();
+    public override void ConfigureServices(HostBuilderContext hostBuilderContext, IServiceCollection services) =>
+        services.AddTransient<ITestService, TestService>();
 }

--- a/src/pscmdlets/core/src/IoCStartup.cs
+++ b/src/pscmdlets/core/src/IoCStartup.cs
@@ -6,15 +6,15 @@
 using AutomationIoC.Runtime;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace AutomationIoC.PSCmdlets;
 
 public abstract class IoCStartup : IIoCStartup
 {
-    public IConfiguration Configuration { get; set; }
     public IAutomationEnvironment AutomationEnvironment { get; set; }
 
     public abstract void Configure(IConfigurationBuilder configurationBuilder);
 
-    public abstract void ConfigureServices(IServiceCollection services);
+    public abstract void ConfigureServices(HostBuilderContext hostBuilderContext, IServiceCollection services);
 }

--- a/src/pscmdlets/core/test/IoCShellTests.cs
+++ b/src/pscmdlets/core/test/IoCShellTests.cs
@@ -18,9 +18,9 @@ public class IoCShellTests
     [Fact]
     public void ShouldLoadDependency()
     {
-        var testServiceMock = new Mock<ITestSdkService>();
+        var testServiceMock = new Mock<ITestPSCmdletService>();
 
-        using IAutomationCommand<TestIoCShell> context = AutomationSandbox.CreateContext<TestIoCShell, TestSDKStartup>(
+        using IAutomationCommand<TestIoCShell> context = AutomationSandbox.CreateContext<TestIoCShell, TestPSCmdletStartup>(
             serviceCollection =>
             {
                 serviceCollection.AddTransient(_ => testServiceMock.Object);
@@ -32,10 +32,10 @@ public class IoCShellTests
     }
 
     [Cmdlet(VerbsData.Mount, "Test")]
-    public class TestIoCShell : IoCShell<TestSDKStartup>
+    public class TestIoCShell : IoCShell<TestPSCmdletStartup>
     {
         [AutomationDependency]
-        protected ITestSdkService TestService { get; set; }
+        protected ITestPSCmdletService TestService { get; set; }
 
         protected override void BeginProcessing()
         {

--- a/src/runtime/src/Context/ContextBuilder.cs
+++ b/src/runtime/src/Context/ContextBuilder.cs
@@ -35,9 +35,9 @@ internal class ContextBuilder : IContextBuilder
 
         IHost hostApplication = GenerateHostBuilder()
             .ConfigureAppConfiguration(startup.Configure)
-            .ConfigureServices(services =>
+            .ConfigureServices((hostBuilderContext, services) =>
             {
-                startup.ConfigureServices(services);
+                startup.ConfigureServices(hostBuilderContext, services);
 
                 RuntimeFactory.AddClientRuntime(services);
             })

--- a/src/runtime/src/Context/ContextBuilder.cs
+++ b/src/runtime/src/Context/ContextBuilder.cs
@@ -34,6 +34,7 @@ internal class ContextBuilder : IContextBuilder
         startup.AutomationEnvironment = automationEnvironment;
 
         IHost hostApplication = GenerateHostBuilder()
+            // .UseEnvironment("Staging")
             .ConfigureAppConfiguration(startup.Configure)
             .ConfigureServices((hostBuilderContext, services) =>
             {
@@ -75,10 +76,10 @@ internal class ContextBuilder : IContextBuilder
     }
 
     private static IHostBuilder GenerateHostBuilder() =>
-        new HostBuilder()
-        .ConfigureLogging(loggingBuilder =>
-        {
-            loggingBuilder.AddDebug();
-            loggingBuilder.AddConsole();
-        });
+        Host.CreateDefaultBuilder()
+            .ConfigureLogging(loggingBuilder =>
+            {
+                loggingBuilder.AddDebug();
+                loggingBuilder.AddConsole();
+            });
 }

--- a/src/runtime/src/IIoCStartup.cs
+++ b/src/runtime/src/IIoCStartup.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace AutomationIoC.Runtime;
 
@@ -12,9 +13,7 @@ public interface IIoCStartup
 {
     IAutomationEnvironment AutomationEnvironment { get; set; }
 
-    IConfiguration Configuration { get; set; }
-
     void Configure(IConfigurationBuilder configurationBuilder);
 
-    void ConfigureServices(IServiceCollection services);
+    void ConfigureServices(HostBuilderContext hostBuilderContext, IServiceCollection services);
 }

--- a/src/runtime/test/AutomationIoC.Runtime.Test.csproj
+++ b/src/runtime/test/AutomationIoC.Runtime.Test.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Bogus" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />

--- a/src/runtime/test/Context/ContextBuilderTests.cs
+++ b/src/runtime/test/Context/ContextBuilderTests.cs
@@ -4,11 +4,12 @@
 // -------------------------------------------------------
 
 using AutomationIoC.Runtime.Attributes;
+using AutomationIoC.Runtime.Dependency;
 using AutomationIoC.Runtime.Models;
 using AutomationIoC.Runtime.Services;
-using AutomationIoC.Runtime.Startup;
-using AutomationIoC.Runtime.Dependency;
 using AutomationIoC.Runtime.Session;
+using AutomationIoC.Runtime.Startup;
+using Bogus;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -36,7 +37,7 @@ public class ContextBuilderTests
     }
 
     [Fact]
-    public void ShouldBuildServices()
+    public void ShouldBuildStartupServices()
     {
         contextBuilder.BuildServices();
 
@@ -44,7 +45,43 @@ public class ContextBuilderTests
 
         storageProviderMock.Verify(provider =>
             provider.StoreHostProvider(It.Is<IHost>(host =>
-                ServiceProviderIsConfiguredFromStartup(host.Services))));
+                ServiceProviderIsConfiguredFromStartup(host.Services))), Times.Once());
+    }
+
+    [Fact]
+    public void ShouldBuildStartupServicesWithHostBuilderContext()
+    {
+        var environmentName = "Staging";
+        var connectionString = new Faker().Internet.Password();
+        var configurationKey = "IPAddress";
+        var configurationValue = new Faker().Internet.Ipv6();
+
+        var hostContextBuilderStartup = new TestHostBuildContextStartup(
+            environmentName: environmentName,
+            connectionString: connectionString,
+            configurationCheckKey: configurationKey,
+            configurationCheckValue: configurationValue);
+
+        var hostContextBuilder = new ContextBuilder(environmentMock.Object, hostContextBuilderStartup, storageProviderMock.Object);
+
+        storageProviderMock.Setup(provider =>
+            provider.StoreHostProvider(It.Is<IHost>(host => ServiceProviderIsConfiguredFromHostContextStartup(host.Services))))
+                .Callback<IHost>((host) =>
+                {
+                    TestHostBuilderContextService test = host.Services.GetRequiredService<TestHostBuilderContextService>();
+
+                    // TODO: Configure environment name in host
+                    // Assert.Equal(environmentName, test.EnvironmentName);
+
+                    Assert.Equal(connectionString, test.ConnectionString);
+                    Assert.Equal(configurationValue, test.ConfigurationValue);
+                });
+
+        hostContextBuilder.BuildServices();
+
+        storageProviderMock.Verify(provider =>
+            provider.StoreHostProvider(It.Is<IHost>(host => ServiceProviderIsConfiguredFromHostContextStartup(host.Services))),
+                Times.Once());
     }
 
     [Fact]
@@ -59,7 +96,7 @@ public class ContextBuilderTests
 
         storageProviderMock.Verify(provider =>
             provider.StoreHostProvider(It.Is<IHost>(host =>
-                ServiceProviderIsConfiguredFromCollection(host.Services))));
+                ServiceProviderIsConfiguredFromCollection(host.Services))), Times.Once());
     }
 
     [Fact]
@@ -106,6 +143,16 @@ public class ContextBuilderTests
         return configuration.GetValue<string>(TestRuntimeStartup.CONFIGURATION_KEY) == TestRuntimeStartup.CONFIGURATION_VALUE &&
             dependencyBinder is not null &&
             testService is not null;
+    }
+
+    private static bool ServiceProviderIsConfiguredFromHostContextStartup(IServiceProvider serviceProvider)
+    {
+        IConfiguration configuration = serviceProvider.GetService<IConfiguration>();
+
+        TestHostBuilderContextService testHostBuilderContextService =
+            serviceProvider.GetService<TestHostBuilderContextService>();
+
+        return configuration is not null && testHostBuilderContextService is not null;
     }
 
     private static bool ServiceProviderIsConfiguredFromCollection(IServiceProvider serviceProvider)

--- a/src/runtime/test/Services/TestHostBuilderContextService.cs
+++ b/src/runtime/test/Services/TestHostBuilderContextService.cs
@@ -1,0 +1,23 @@
+﻿// -------------------------------------------------------
+// Copyright (c) Ken Swan All rights reserved.
+// Licensed under the MIT License
+// -------------------------------------------------------
+
+namespace AutomationIoC.Runtime.Services;
+
+internal class TestHostBuilderContextService
+{
+    public string EnvironmentName { get; private set; }
+    public string ConnectionString { get; private set; }
+    public string ConfigurationValue { get; private set; }
+
+    public TestHostBuilderContextService(
+        string environmentName,
+        string connectionString,
+        string configurationValue)
+    {
+        this.EnvironmentName = environmentName;
+        this.ConnectionString = connectionString;
+        this.ConfigurationValue = configurationValue;
+    }
+}

--- a/src/runtime/test/Startup/TestHostBuildContextStartup.cs
+++ b/src/runtime/test/Startup/TestHostBuildContextStartup.cs
@@ -1,0 +1,61 @@
+﻿// -------------------------------------------------------
+// Copyright (c) Ken Swan All rights reserved.
+// Licensed under the MIT License
+// -------------------------------------------------------
+
+using AutomationIoC.Runtime.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace AutomationIoC.Runtime.Startup;
+
+public class TestHostBuildContextStartup : IIoCStartup
+{
+    private readonly string environmentName;
+    private readonly string connectionString;
+    private readonly string configurationCheckKey;
+    private readonly string configurationCheckValue;
+    private readonly string connectionStringKey = "TestDefaultConnection";
+
+    public TestHostBuildContextStartup(
+        string environmentName,
+        string connectionString,
+        string configurationCheckKey,
+        string configurationCheckValue)
+    {
+        this.environmentName = environmentName;
+        this.connectionString = connectionString;
+        this.configurationCheckKey = configurationCheckKey;
+        this.configurationCheckValue = configurationCheckValue;
+    }
+
+    public IConfiguration Configuration { get; set; }
+
+    public IAutomationEnvironment AutomationEnvironment { get; set; }
+
+    public void Configure(IConfigurationBuilder configurationBuilder)
+    {
+        var appSettings = new Dictionary<string, string>()
+        {
+            [configurationCheckKey] = configurationCheckValue,
+            ["DOTNET_ENVIRONMENT"] = environmentName,
+            [$"ConnectionStrings:{connectionStringKey}"] = connectionString
+        };
+
+        configurationBuilder.AddInMemoryCollection(appSettings);
+        configurationBuilder.AddEnvironmentVariables();
+    }
+
+    public void ConfigureServices(HostBuilderContext hostBuilderContext, IServiceCollection services)
+    {
+        var environmentName = hostBuilderContext.HostingEnvironment.EnvironmentName;
+        var connectionString = hostBuilderContext.Configuration.GetConnectionString(connectionStringKey);
+        var configurationValue = hostBuilderContext.Configuration.GetValue<string>(configurationCheckKey);
+
+        services.AddScoped(_ => new TestHostBuilderContextService(
+            environmentName: environmentName,
+            connectionString: connectionString,
+            configurationValue: configurationValue));
+    }
+}

--- a/src/runtime/test/Startup/TestRuntimeStartup.cs
+++ b/src/runtime/test/Startup/TestRuntimeStartup.cs
@@ -6,6 +6,7 @@
 using AutomationIoC.Runtime.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace AutomationIoC.Runtime.Startup;
 
@@ -28,7 +29,7 @@ public class TestRuntimeStartup : IIoCStartup
         configurationBuilder.AddInMemoryCollection(appSettings);
     }
 
-    public void ConfigureServices(IServiceCollection services) => services
+    public void ConfigureServices(HostBuilderContext hostBuilderContext, IServiceCollection services) => services
             .AddTransient<ITestRuntimeService, TestRuntimePropertyService>()
             .AddTransient<ITestRuntimeService, TestRuntimeFieldService>()
             .AddTransient<ITestRuntimeInternalServiceOne, TestRuntimeInternalServiceOne>()


### PR DESCRIPTION
Allow consumers to leverage configuration and environment information generated during startup configuration in the configuration of services